### PR TITLE
Minor changes

### DIFF
--- a/t/ModelCoupling/SConstruct
+++ b/t/ModelCoupling/SConstruct
@@ -15,7 +15,7 @@ FFLAGS=['-std=c++11','-Wall', '-DWORDSZ=64', '-DUSE_THREADS=1']
 CXXFLAGS=[ '-Wall',  '-std=c++11' ,  '-DWORDSZ=64', '-DUSE_THREADS=1']
 INCPATHS=[ GANNET_DIR+'/GPRM/src', GANNET_DIR+'/GPRM/src/SBA',  wd+'/gensrc']
 LIBPATHS=[wd+'/lib', wd+'/src/GMCF/Models']
-LIBS=[ 'gmcf']+modellibs+['gmcfAPI', 'gfortran']
+LIBS=[ 'gmcf']+modellibs+['gmcfAPI', 'gmcf', 'gfortran']
 env=Environment(LINK=CXX,LINKFLAGS=LDFLAGS,CXX=CXX,CXXFLAGS=CXXFLAGS,CPPPATH=INCPATHS,LIBPATH=LIBPATHS)
 env.Program('gmcfCoupler',gmcfsources,LIBS=LIBS) 
 

--- a/t/ModelCoupling/src/GMCF/Models/gmcfAPImodel1.f95
+++ b/t/ModelCoupling/src/GMCF/Models/gmcfAPImodel1.f95
@@ -75,7 +75,7 @@ contains
             ! and then we read them
             call gmcfHasPackets(model1_id,RESPDATA,has_packets)
             do while (has_packets==1)
-                call gmcfShiftPending(model1_id,RESPDATA,DEST_2,packet,fifo_empty)
+                call gmcfShiftPending(model1_id,DEST_2,RESPDATA,packet,fifo_empty)
                 ! read a packet
                 select case (packet%data_id) ! <code for the variable var_name, GMCF-style>
                     case (GMCF_VAR_NAME_1)

--- a/t/ModelCoupling/src/GMCF/Models/gmcfAPImodel2.f95
+++ b/t/ModelCoupling/src/GMCF/Models/gmcfAPImodel2.f95
@@ -72,7 +72,7 @@ contains
         end if ! FIN
 
         if (gmcfStatus(DEST_1) /= FIN) then
-            call gmcfShiftPending(model2_id,REQDATA,DEST_1,packet, fifo_empty)
+            call gmcfShiftPending(model2_id,DEST_1,REQDATA,packet, fifo_empty)
             print *,"FORTRAN MODEL2: GOT a REQDATA packet (PRE) from ",packet%source,'to',packet%destination
             select case (packet%data_id)
                 case (GMCF_VAR_NAME_1)
@@ -103,7 +103,7 @@ contains
         if (gmcfStatus(DEST_1) /= FIN) then
         call gmcfHasPackets(model2_id,REQDATA,has_packets)
         if (has_packets==1) then
-        call gmcfShiftPending(model2_id,REQDATA,DEST_1,packet,fifo_empty)
+        call gmcfShiftPending(model2_id,DEST_1,REQDATA,packet,fifo_empty)
         select case (packet%data_id)
             case (GMCF_VAR_NAME_2)
             if (packet%pre_post == POST) then

--- a/t/ModelCoupling/src/GMCF/Models/model1.f95
+++ b/t/ModelCoupling/src/GMCF/Models/model1.f95
@@ -109,7 +109,7 @@ subroutine program_model1(sys, tile, model_id) ! This replaces 'program main'
             ! and then we read them
             call gmcfHasPackets(model_id,RESPDATA,has_packets)
             do while (has_packets==1)
-                call gmcfShiftPending(model_id,RESPDATA,packet,fifo_empty)
+                call gmcfShiftPending(model_id,DEST_2,RESPDATA,packet,fifo_empty)
                 ! read a packet
                 select case (packet%data_id) ! <code for the variable var_name, GMCF-style>
                     case (GMCF_VAR_NAME_1)

--- a/t/ModelCoupling/src/GMCF/Models/model2.f95
+++ b/t/ModelCoupling/src/GMCF/Models/model2.f95
@@ -106,7 +106,7 @@ subroutine program_model2(sys, tile, model_id) ! This replaces 'program main'
         end if ! FIN
 
         if (gmcfStatus(DEST_1) /= FIN) then
-        call gmcfShiftPending(model_id,REQDATA,packet, fifo_empty)
+        call gmcfShiftPending(model_id,DEST_1,REQDATA,packet, fifo_empty)
         print *,"FORTRAN MODEL2: GOT a REQDATA packet (PRE) from ",packet%source,'to',packet%destination
         select case (packet%data_id)
             case (GMCF_VAR_NAME_1)
@@ -148,7 +148,7 @@ subroutine program_model2(sys, tile, model_id) ! This replaces 'program main'
         if (gmcfStatus(DEST_1) /= FIN) then
         call gmcfHasPackets(model_id,REQDATA,has_packets)
         if (has_packets==1) then
-        call gmcfShiftPending(model_id,REQDATA,packet,fifo_empty)
+        call gmcfShiftPending(model_id,DEST_1,REQDATA,packet,fifo_empty)
         select case (packet%data_id)
             case (GMCF_VAR_NAME_2)
             if (packet%pre_post == POST) then


### PR DESCRIPTION
The SConstruct change is confusing. This stops the SBA::InclusionSetTable::<method> linker error on my machine. Not entirely sure I need both. Perhaps a version difference in scons or something since our compilers are both g++-4.9. I have scons v2.1.0.r5357 from year 2011.

The producer/consumer changes bring the gmcfShiftPending API change to the model<i>.f95 files themselves and also fixes the order of things (I got the order wrong in the meeting sorry).
