### PR TITLE
REGREADY + Refactor

### DIFF
--- a/GPRM/src/SBA/ServiceManager.cc
+++ b/GPRM/src/SBA/ServiceManager.cc
@@ -225,6 +225,15 @@ using namespace SBA;
 			 fin_fifo.push_back(packet);
 		   break;
 		  }
+		  case P_RRDY :
+		  {
+#ifdef VERBOSE
+			 cout << service << " P_RRDY\n";
+#endif // VERBOSE
+             Packet_Fifo& regrdy_fifo = regrdy_fifo_tbl[src];
+			 regrdy_fifo.push_back(packet);
+		   break;
+		  }
            default:
             cerr << "Packet Type <" <<packet_type<< "> not recognised";
             exit(1);

--- a/GPRM/src/gmcfAPI.f95
+++ b/GPRM/src/gmcfAPI.f95
@@ -560,4 +560,14 @@ contains
         call gmcfsettakefirstc(sba_tile(model_id), set_id, src_model_id)
     end subroutine gmcfSetTakeFirst
 
+    subroutine gmcfSendRegReady(model_id, set_id, destination)
+        integer, intent(In) :: model_id, set_id, destination
+        call gmcfsendpacketc(sba_sys, sba_tile(model_id), model_id, destination, REGREADY, set_id, PRE, -1 ,ONE, 0)
+    end subroutine gmcfSendRegReady
+
+    subroutine gmcfSendAck(model_id, set_id, destination)
+        integer, intent(In) :: model_id, set_id, destination
+        call gmcfsendpacketc(sba_sys, sba_tile(model_id), model_id, destination, ACKDATA, set_id, PRE, -1 ,ONE, 0)
+    end subroutine gmcfSendAck
+
 end module gmcfAPI

--- a/GPRM/src/gmcfC.h
+++ b/GPRM/src/gmcfC.h
@@ -59,7 +59,7 @@ void gmcfsettakefirstc_(int64_t* ivp_tileptr, int* set_id, int* model_id);
 void gmcfgetpthreadidc_(int64_t*id);
 
 void gmcfwriteregc_(int64_t* ivp_sysptr, int model_id, int regno, void* word);
-void gmcfreadregc_(int64_t* ivp_sysptr, int model_id, int regno, void* word);
+void gmcfreadregc_(int64_t* ivp_sysptr, int model_id, int regno, int64_t* word);
 
 void gmcflockregc_(int64_t* ivp_sysptr, int model_id);
 void gmcfunlockregc_(int64_t* ivp_sysptr, int model_id);


### PR DESCRIPTION
Since you mentioned about merging some thread pinning code, I thought it best we align our repos up.
The changes add support for P_RRDY packets and also refactors gmcfF.cc since there was a lot of duplication (case statements to get fifo/fifo table with identical logic) so I've refactored the fifo/fifo table case statements out to separate functions and thus logic is only there once. Also makes it much easier to add/remove support for packet types in the future.

Seems to run okay on the t/ModelCoupling and micro benchmarks so I don't think it has broken anything.
