### PR TITLE
Thread pinning, spin lock, fast global reduction

### DIFF
--- a/GPRM/src/SBA/Schedule.cc
+++ b/GPRM/src/SBA/Schedule.cc
@@ -1,8 +1,8 @@
-#include "../../../launcher.h" //multiple definition of `chip_array' if places in Schedule.h
+#include <cstdio>
+#include <pthread.h>
 #include "Schedule.h"
 #ifndef DARWIN
 #define _GNU_SOURCE
-#include <sched.h> // thread mapping
 #endif
 #define RESET_COLOR "\e[m"
 #define MAKE_PURPLE "\e[35m"
@@ -34,7 +34,7 @@ int appid = 0;
 
 	CPU_SET(target_core, &mask);
 	if (sched_setaffinity(0, sizeof(mask), &mask) !=0)
-		perror("sched_setaffinity");
+		fprintf(stderr, "sched_setaffinity\n");
 	return target_core;
  }
 

--- a/GPRM/src/SBA/SpinLock.h
+++ b/GPRM/src/SBA/SpinLock.h
@@ -1,0 +1,48 @@
+#ifndef __SPINLOCK__
+
+#define __SPINLOCK__
+
+#include <pthread.h>
+
+#ifdef __APPLE__
+#define EBUSY 16
+typedef int pthread_spinlock_t;
+
+int pthread_spin_init(pthread_spinlock_t *lock, int pshared) {
+    __asm__ __volatile__ ("" ::: "memory");
+    *lock = 0;
+    return 0;
+}
+
+int pthread_spin_destroy(pthread_spinlock_t *lock) {
+    return 0;
+}
+
+int pthread_spin_lock(pthread_spinlock_t *lock) {
+    while (1) {
+        int i;
+        for (i=0; i < 10000; i++) {
+            if (__sync_bool_compare_and_swap(lock, 0, 1)) {
+                return 0;
+            }
+        }
+        sched_yield();
+    }
+}
+
+int pthread_spin_trylock(pthread_spinlock_t *lock) {
+    if (__sync_bool_compare_and_swap(lock, 0, 1)) {
+        return 0;
+    }
+    return EBUSY;
+}
+
+int pthread_spin_unlock(pthread_spinlock_t *lock) {
+    __asm__ __volatile__ ("" ::: "memory");
+    *lock = 0;
+    return 0;
+}
+#endif
+
+#endif
+

--- a/GPRM/src/SBA/Tile.cc
+++ b/GPRM/src/SBA/Tile.cc
@@ -70,21 +70,25 @@ void Tile::run() {
 #ifdef VERBOSE
     cout << "Starting Tile " << service << "\n";
 #endif // VERBOSE
-    	thread_mapping(address);
+//    	thread_mapping(address);
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(service - 1, &cpuset);
         pthread_attr_init(&attr);
+        pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &cpuset);
         pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
         pthread_create(&tid, &attr, SBA::run_tile_loop, (void*)this);
         //cout << "Thread ID: " << pthread_self() << endl;
 #if 0
 // WV: Thread pinning, untested and unused, using Ashkan's approach instead
 #ifndef DARWIN
-		cpu_set_t cpuset;
-		CPU_ZERO(&cpuset);
-		CPU_SET(service, &cpuset);
-		int st = pthread_setaffinity_np(tid, sizeof(cpu_set_t), &cpuset);
-		if (st != 0) {
-		  std::cerr <<"Could not set affinity on thread " << tid << "\n";
-		}
+//		cpu_set_t cpuset;
+//		CPU_ZERO(&cpuset);
+//		CPU_SET(service, &cpuset);
+//		int st = pthread_setaffinity_np(tid, sizeof(cpu_set_t), &cpuset);
+//		if (st != 0) {
+//		  std::cerr <<"Could not set affinity on thread " << tid << "\n";
+//		}
 #endif
 #endif
         //printf("Thread ID:   %ld  Created on the Tile Adress: %d \n", tid, address);

--- a/GPRM/src/SBA/Types.h
+++ b/GPRM/src/SBA/Types.h
@@ -27,6 +27,7 @@
 
 #if USE_THREADS==1
 #include <pthread.h>
+#include "SpinLock.h"
 #endif
 
 #include <iostream> // for cerr & cout!!
@@ -779,20 +780,20 @@ public:
 class RX_Packet_Fifo {
 	private:
     	deque<Packet_t> packets;
-    	pthread_mutex_t _RXlock;
+    	pthread_spinlock_t _RXlock;
  	bool _status;
 	public:
  		RX_Packet_Fifo () :  _status(0) {
- 			pthread_mutex_init(&_RXlock, NULL);
+ 			pthread_spin_init(&_RXlock, PTHREAD_PROCESS_SHARED);
  		};
  		~RX_Packet_Fifo() {
- 			pthread_mutex_destroy(&_RXlock);
+ 			pthread_spin_destroy(&_RXlock);
  		}
  	bool status() {
  		//FIXME: make this blocking? Ashkan added lock & unlock
- 		pthread_mutex_lock(&_RXlock);
+ 		pthread_spin_lock(&_RXlock);
  		bool stat = _status;
- 		pthread_mutex_unlock(&_RXlock);
+ 		pthread_spin_unlock(&_RXlock);
      	return stat;
  	}
 
@@ -804,9 +805,9 @@ class RX_Packet_Fifo {
     bool has_packets() {
 // we want to block until the status is true
 // so status() will block until it can return true
- 	  pthread_mutex_lock(&_RXlock);
+ 	  pthread_spin_lock(&_RXlock);
  	 bool has = (_status==1);
- 	  pthread_mutex_unlock(&_RXlock);
+ 	  pthread_spin_unlock(&_RXlock);
  	  return(has);
     }
 
@@ -869,10 +870,10 @@ class RX_Packet_Fifo {
     }
 */
     void push_back(Packet_t const& data) {
-        pthread_mutex_lock(&_RXlock);
+        pthread_spin_lock(&_RXlock);
         packets.push_back(data);
         _status=1;
-        pthread_mutex_unlock(&_RXlock);
+        pthread_spin_unlock(&_RXlock);
       }
 
 /*    Packet_t front() {
@@ -893,11 +894,11 @@ class RX_Packet_Fifo {
         	cout << "RX_Packet_Fifo: Thread Blocked For Some Strange Reason!" << endl;
         	__asm__ __volatile__ ("" ::: "memory");
         }
-        pthread_mutex_lock(&_RXlock);
+        pthread_spin_lock(&_RXlock);
         Packet_t t_elt=packets.front();
         packets.pop_front();
         if (packets.size() == 0) _status=0;
-        pthread_mutex_unlock(&_RXlock);
+        pthread_spin_unlock(&_RXlock);
 
 #ifdef VERBOSE
         cout << "RX_Packet_Fifo: DONE pop_front() \n";

--- a/GPRM/src/gmcfAPI.f95
+++ b/GPRM/src/gmcfAPI.f95
@@ -581,5 +581,11 @@ contains
     subroutine gmcfUnlockGlobalOpSpinLock()
         call gmcfunlockglobalopspinlockc()
     end subroutine
+    
+    subroutine gmcfDoOp(model_id, value, tag, instances)
+        integer, intent(in) :: model_id, tag, instances
+        real(kind=4), intent(inout) :: value
+        call gmcfdoopc(model_id, value, tag, instances)
+    end subroutine
 
 end module gmcfAPI

--- a/GPRM/src/gmcfAPI.f95
+++ b/GPRM/src/gmcfAPI.f95
@@ -570,4 +570,16 @@ contains
         call gmcfsendpacketc(sba_sys, sba_tile(model_id), model_id, destination, ACKDATA, set_id, PRE, -1 ,ONE, 0)
     end subroutine gmcfSendAck
 
+    subroutine gmcfInitGlobalOpSpinLock()
+        call gmcfinitglobalopspinlockc()
+    end subroutine    
+
+    subroutine gmcfLockGlobalOpSpinLock()
+        call gmcflockglobalopspinlockc()
+    end subroutine
+
+    subroutine gmcfUnlockGlobalOpSpinLock()
+        call gmcfunlockglobalopspinlockc()
+    end subroutine
+
 end module gmcfAPI

--- a/GPRM/src/gmcfC.h
+++ b/GPRM/src/gmcfC.h
@@ -66,4 +66,8 @@ void gmcfunlockregc_(int64_t* ivp_sysptr, int model_id);
 
 void gmcfwaitforregsc_(int64_t* ivp_sysptr,int64_t* ivp_tileptr,  int* model_id);
 
+void gmcfinitglobalopspinlockc_();
+void gmcflockglobalopspinlockc_();
+void gmcfunlockglobalopspinlockc_();
+
 #endif // _GMCF_C_H_

--- a/GPRM/src/gmcfC.h
+++ b/GPRM/src/gmcfC.h
@@ -70,4 +70,6 @@ void gmcfinitglobalopspinlockc_();
 void gmcflockglobalopspinlockc_();
 void gmcfunlockglobalopspinlockc_();
 
+void gmcfdoopc_(int *id, float *value, int *tag, int *size);
+
 #endif // _GMCF_C_H_

--- a/GPRM/src/gmcfF.cc
+++ b/GPRM/src/gmcfF.cc
@@ -3,8 +3,11 @@
 #include "SBA/System.h"
 #include "SBA/Tile.h"
 #include "SBA/Packet.h"
+#include "SBA/SpinLock.h"
 #include <cstring>
 #include <pthread.h>
+
+pthread_spinlock_t globalOpSpinLock;
 
 //#define GMCF_DEBUG
 /*
@@ -513,4 +516,14 @@ void gmcfwaitforregsc_(int64_t* ivp_sysptr,int64_t* ivp_tileptr,  int* model_id)
 	}
 }
 
+void gmcfinitglobalopspinlockc_() {
+    pthread_spin_init(&globalOpSpinLock, PTHREAD_PROCESS_SHARED);
+}
 
+void gmcflockglobalopspinlockc_() {
+    pthread_spin_lock(&globalOpSpinLock);
+}
+
+void gmcfunlockglobalopspinlockc_() {
+    pthread_spin_unlock(&globalOpSpinLock);
+}


### PR DESCRIPTION
This pull request brings the repository up to where the 'best' runs for GMCF came from. Changings include:

Thread-pinning:
- Ashkan's and Wim's code commented out. Adds known-working thread-pinning code.

Spin lock:
- RX_Packet_Fifo has a spin lock with busy wait rather than a mutex with condition variables. This helps performance a little bit but causes two cores to be 'wasted' on the two non-model threads. For this reason you may wish to delay/reject the pull request.

Fast global reduction:
- Using spin locks (separate to RX_Packet_Fifo, a C/C++-side global reduction for max, min, and sum is added.
